### PR TITLE
[FIXED JENKINS-19518]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version>
+    <version>1.480</version>
   </parent>
 
   <artifactId>offlineonfailure-plugin</artifactId>

--- a/src/main/java/com/polopoly/jenkins/plugin/offlineonfailure/OfflineOnFailurePublisher.java
+++ b/src/main/java/com/polopoly/jenkins/plugin/offlineonfailure/OfflineOnFailurePublisher.java
@@ -52,7 +52,7 @@ public class OfflineOnFailurePublisher
 
     public BuildStepMonitor getRequiredMonitorService()
     {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     /*


### PR DESCRIPTION
- Changed getRequiredMonitorService() return value to
  BuildStepMonitor.NONE because a failure is not dependant on previous
  build.
